### PR TITLE
fix: add types location to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
 		"husky": "^8.0.1",
 		"lint-staged": "^13.0.3",
 		"prettier": "^2.7.1"
-	}
+	},
+	"types": "./typings/index.d.ts"
 }


### PR DESCRIPTION
some editors may not know the location of it otherwise, and the TypeScript docs say it's required as so:
![Screenshot_20220802_030314](https://user-images.githubusercontent.com/29015942/182275960-dc2e24b6-6cca-48ef-974c-4b7f5ab69abb.png)

